### PR TITLE
pidl: Added new 'ANY' charset argument

### DIFF
--- a/pidl/lib/Parse/Pidl/Samba4/TDR.pm
+++ b/pidl/lib/Parse/Pidl/Samba4/TDR.pm
@@ -86,6 +86,11 @@ sub ParserElement($$$$)
 		my $len = ParseExpr(@{$e->{ARRAY_LEN}}[0], $env, $e);
 		if ($len eq "*") { $len = "-1"; }
 		$name = ", mem_ctx" if ($t eq "pull");
+
+		if (($e->{PROPERTIES}->{charset} eq 'ANY')) {
+		    return;
+		}
+
 		$self->pidl("TDR_CHECK(tdr_$t\_charset(tdr$name, &v->$e->{NAME}, $len, sizeof($e->{TYPE}_t), CH_$e->{PROPERTIES}->{charset}));");
 		return;
 	}


### PR DESCRIPTION
The ANY character set is to be used for 8bit characters
which can came in any encoding or in a unsupported encoding.
(for example, DOS codepages)

The ANY character set has the following properties:
- it does not have any incorrect character check.
- besides that has the same behaviour of an UNIX charset,
  thus avoiding byte conversions.
